### PR TITLE
add entry point to setup.py for console_scrips, for run wordcount_beam

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name='data-core-pipelines-beam',
-    version='0.0.2',
+    version='0.0.3',
     description='TDD core project to develop Apache Beam with Python SDK',
     author='Israel Martinez @israndroid',
     packages=setuptools.find_packages(
@@ -15,6 +15,11 @@ setuptools.setup(
             , 'tests.*'
             ]
     ),
+    entry_points={
+        'console_scripts': [
+            'wordcount_beam=src.modules.wordcount_minimal:main'
+            ] # so this directly refers to a function available in __init__.py
+        },
     install_requires=[
         'apache-beam[gcp]==2.65.0',
         # Puedes agregar otras dependencias aquí si las necesitas


### PR DESCRIPTION
Enable wordcount_beam at setup how entry_script, 2 option to run pipeline from data-core-pipelines-beam (first pipeline)


`python -m src.modules.wordcount_minimal --runner DirectRunner --input ./tests/input/ch1_les_miserables.txt --output ./tests/output/word_counts_ch1_les_miserables.txt`

`wordcount_beam --runner DirectRunner --input ./tests/input/ch1_les_miserables.txt --output ./tests/output/word_counts_ch1_les_miserables.txt`